### PR TITLE
Fix event time and capacity

### DIFF
--- a/src/app/actions/events/actions.ts
+++ b/src/app/actions/events/actions.ts
@@ -23,23 +23,24 @@ export async function getEvents() {
     await connectDB();
 
     const events = await Event.find().sort({ startDate: 1 }).lean<LeanEvent[]>();
-
     return events.map((event) => {
       return {
         _id: event._id.toString(),
         title: event.title,
         description: event.description,
-        // Only call toISOString() if `start` is valid
-        startDate: event.startDate ? new Date(event.startDate).toISOString() : null,
-
-        // Repeat the same pattern for `endDate`
-        endDate: event.endDate ? new Date(event.endDate).toISOString() : null,
+        startDate: event.startDate
+          ? new Date(event.startDate).toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
+          : null,
+        endDate: event.endDate
+          ? new Date(event.endDate).toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
+          : null,
 
         location: event.location,
         capacity: event.capacity,
         registrationDeadline: event.registrationDeadline ? new Date(event.registrationDeadline).toISOString() : null,
         images: event.images || [],
         currentRegistrations: event.registeredUsers?.length || 0,
+        registeredUsers: event.registeredUsers ? event.registeredUsers.map((user: any) => user.toString()) : [],
         fee: event.fee,
       };
     });

--- a/src/app/actions/events/actions.ts
+++ b/src/app/actions/events/actions.ts
@@ -28,16 +28,11 @@ export async function getEvents() {
         _id: event._id.toString(),
         title: event.title,
         description: event.description,
-        startDate: event.startDate
-          ? new Date(event.startDate).toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
-          : null,
-        endDate: event.endDate
-          ? new Date(event.endDate).toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
-          : null,
-
+        startDate: event.startDate ? new Date(event.startDate).toLocaleString() : null,
+        endDate: event.endDate ? new Date(event.endDate).toLocaleString() : null,
         location: event.location,
         capacity: event.capacity,
-        registrationDeadline: event.registrationDeadline ? new Date(event.registrationDeadline).toISOString() : null,
+        registrationDeadline: event.registrationDeadline ? new Date(event.registrationDeadline).toLocaleString() : null,
         images: event.images || [],
         currentRegistrations: event.registeredUsers?.length || 0,
         registeredUsers: event.registeredUsers ? event.registeredUsers.map((user: any) => user.toString()) : [],

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -49,10 +49,15 @@ export default function AdminPage() {
 
     const interval = setInterval(() => {
       fetchEvents();
-    }, 30000);
+    }, 300000);
 
     return () => clearInterval(interval);
   }, []);
+
+  // Function to remove deleted event from state
+  const handleDeleteEvent = (eventId: string) => {
+    setEvents((prevEvents) => prevEvents.filter((event) => event._id !== eventId));
+  };
 
   return (
     <div>
@@ -74,6 +79,7 @@ export default function AdminPage() {
             registrationDeadline={event.registrationDeadline}
             capacity={event.capacity}
             currentRegistrations={event.registeredUsers.length}
+            onDelete={handleDeleteEvent}
           />
         ))}
       </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -21,32 +21,38 @@ interface IEvent {
 export default function AdminPage() {
   const [events, setEvents] = useState<IEvent[]>([]);
 
-  useEffect(() => {
-    async function fetchEvents() {
-      try {
-        const data = await getEvents();
+  const fetchEvents = async () => {
+    try {
+      const data = await getEvents();
 
-        // Transform MongoDB objects into `IEvent` format
-        const formattedEvents: IEvent[] = data.map((event: any) => ({
-          _id: event._id.toString(),
-          title: event.title || "Untitled Event",
-          startDateTime: event.startDate ? new Date(event.startDate) : null,
-          endDateTime: event.endDate ? new Date(event.endDate) : null,
-          location: event.location || "Location not available",
-          description: event.description || "No description provided",
-          images: Array.isArray(event.images) ? event.images : [],
-          registrationDeadline: event.registrationDeadline ? new Date(event.registrationDeadline) : null,
-          capacity: event.capacity || 0,
-          registeredUsers: event.registeredUsers ? event.registeredUsers.map((user: any) => user.toString()) : [],
-        }));
+      // Transform MongoDB objects into `IEvent` format
+      const formattedEvents: IEvent[] = data.map((event: any) => ({
+        _id: event._id.toString(),
+        title: event.title || "Untitled Event",
+        startDateTime: event.startDate ? new Date(event.startDate) : null,
+        endDateTime: event.endDate ? new Date(event.endDate) : null,
+        location: event.location || "Location not available",
+        description: event.description || "No description provided",
+        images: Array.isArray(event.images) ? event.images : [],
+        registrationDeadline: event.registrationDeadline ? new Date(event.registrationDeadline) : null,
+        capacity: event.capacity || 0,
+        registeredUsers: event.registeredUsers ? event.registeredUsers.map((user: any) => user.toString()) : [],
+      }));
 
-        setEvents(formattedEvents);
-      } catch (error) {
-        console.error("Error fetching events:", error);
-      }
+      setEvents(formattedEvents);
+    } catch (error) {
+      console.error("Error fetching events:", error);
     }
+  };
 
+  useEffect(() => {
     fetchEvents();
+
+    const interval = setInterval(() => {
+      fetchEvents();
+    }, 30000);
+
+    return () => clearInterval(interval);
   }, []);
 
   return (

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -36,9 +36,8 @@ export default function AdminPage() {
         images: Array.isArray(event.images) ? event.images : [],
         registrationDeadline: event.registrationDeadline ? new Date(event.registrationDeadline) : null,
         capacity: event.capacity || 0,
-        registeredUsers: event.registeredUsers ? event.registeredUsers.map((user: any) => user.toString()) : [],
+        registeredUsers: event.registeredUsers,
       }));
-
       setEvents(formattedEvents);
     } catch (error) {
       console.error("Error fetching events:", error);

--- a/src/components/EventComponent/EventCard.tsx
+++ b/src/components/EventComponent/EventCard.tsx
@@ -16,6 +16,7 @@ export interface EventCardProps {
   registrationDeadline: Date | null;
   capacity: number;
   currentRegistrations: number;
+  onDelete: (eventId: string) => void;
 }
 
 export default function EventCard({
@@ -29,6 +30,7 @@ export default function EventCard({
   registrationDeadline,
   capacity,
   currentRegistrations,
+  onDelete,
 }: EventCardProps) {
   const backgroundImage =
     images.length > 0
@@ -100,6 +102,7 @@ export default function EventCard({
           registrationDeadline={registrationDeadline}
           capacity={capacity}
           currentRegistrations={currentRegistrations}
+          onDelete={onDelete}
         />
       </CardContent>
     </Card>

--- a/src/components/EventComponent/EventForm.tsx
+++ b/src/components/EventComponent/EventForm.tsx
@@ -29,8 +29,8 @@ export default function CreateEventForm() {
 
   const onSubmit = async (data: EventFormData, isDraft: boolean) => {
     // Combine date and time into ISO 8601 format for MongoDB
-    const startDateTime = new Date(`${data.startDate}T${data.startTime}:00Z`).toISOString();
-    const endDateTime = new Date(`${data.endDate}T${data.endTime}:00Z`).toISOString();
+    const startDateTime = new Date(`${data.startDate}T${data.startTime}:00`).toISOString();
+    const endDateTime = new Date(`${data.endDate}T${data.endTime}:00`).toISOString();
     const registrationDeadline = new Date(data.registrationDeadline).toISOString();
 
     // Validate start and end times

--- a/src/components/EventComponent/EventForm.tsx
+++ b/src/components/EventComponent/EventForm.tsx
@@ -28,10 +28,13 @@ export default function CreateEventForm() {
   } = useForm<EventFormData>();
 
   const onSubmit = async (data: EventFormData, isDraft: boolean) => {
-    // start/end date validation
-    const startDateTime = new Date(data.startDate + "T" + data.startTime);
-    const endDateTime = new Date(data.endDate + "T" + data.endTime);
-    if (endDateTime <= startDateTime) {
+    // Combine date and time into ISO 8601 format for MongoDB
+    const startDateTime = new Date(`${data.startDate}T${data.startTime}:00Z`).toISOString();
+    const endDateTime = new Date(`${data.endDate}T${data.endTime}:00Z`).toISOString();
+    const registrationDeadline = new Date(data.registrationDeadline).toISOString();
+
+    // Validate start and end times
+    if (new Date(endDateTime) <= new Date(startDateTime)) {
       toast({
         title: "Unable to Create Event!",
         variant: "destructive",
@@ -41,7 +44,18 @@ export default function CreateEventForm() {
       return;
     }
 
-    // start loading
+    // Prepare data for MongoDB
+    const eventData = {
+      title: data.title,
+      description: data.description,
+      startDate: startDateTime,
+      endDate: endDateTime,
+      location: data.location,
+      capacity: Number(data.maxParticipants),
+      registrationDeadline: registrationDeadline,
+      fee: Number(data.fee),
+    };
+
     setIsSubmitting(true);
     console.log(data, isDraft ? "Saved as Draft" : "Published");
 
@@ -50,10 +64,8 @@ export default function CreateEventForm() {
       try {
         const response = await fetch("/api/events", {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ ...data }),
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(eventData),
         });
 
         if (response.ok) {

--- a/src/components/EventComponent/EventInfoPreview.tsx
+++ b/src/components/EventComponent/EventInfoPreview.tsx
@@ -31,6 +31,7 @@ interface EventInfoProps {
   email?: string;
   capacity?: number;
   currentRegistrations?: number;
+  onDelete: (eventId: string) => void;
 }
 
 export function EventInfoPreview({
@@ -45,6 +46,7 @@ export function EventInfoPreview({
   email = "info@creeklands.org",
   capacity,
   currentRegistrations,
+  onDelete,
 }: EventInfoProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -78,7 +80,8 @@ export function EventInfoPreview({
         description: "The event has been removed from the system.",
       });
 
-      window.location.reload();
+      // Calls onDelete to remove deleted events from events instead of full reload
+      onDelete(id);
     } catch (error) {
       toast({
         title: "Error",


### PR DESCRIPTION
## Developer: Brandon Wong

Closes #62 

### Pull Request Summary

Fix event time and capacity

### Modifications

- src/app/admin/page.tsx  
    - Combined startDate/startTime and endDate/endTime into ISO 8601 strings for MongoDB.
    - Renamed maxParticipants to capacity and ensured numeric conversion.
- src/components/EventComponent/EventForm.tsx - Fix event time and capacity
    - Added polling with useEffect to fetch events every 30 seconds for dynamic registeredUsers updates.
    - 
### Testing Considerations
- Manual event creation 


### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="473" alt="image" src="https://github.com/user-attachments/assets/2a555c33-4598-4c99-a608-124b337ef1f0" />
