### PR TITLE
patched middelware logic on api calls

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 
 const isOnboardingRoute = createRouteMatcher(["/onboarding", "/onboarding/children"]);
+const isApiRoute = createRouteMatcher(["/api(.*)"]);
 const isPublicRoute = createRouteMatcher(["/", "/api/webhooks/clerk"]);
 const isAdminRoute = createRouteMatcher(["/admin(.*)"]);
 
@@ -9,8 +10,8 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
   const { userId, sessionClaims, redirectToSignIn } = await auth();
   const role = sessionClaims?.metadata?.userRole;
 
-  // For users visiting /onboarding, don't try to redirect
-  if (userId && isOnboardingRoute(req)) {
+  // don't onboard API calls, but still require login
+  if (userId && (isOnboardingRoute(req) || isApiRoute(req))) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Developer: Kevin Diaz


### Pull Request Summary

middleware used to break the home page for non-onboarded users, since it would try to redirect an api call to the onboarding page. It would result in a JSON parsing error. I feel like this might be an issue in other places as well so I made a pr just for this.

### Modifications

- `middleware.ts` added a matcher for api routes to prevent redirects to onboarding

### Testing Considerations

Not much, check that the home page now loads if the user is not onboarded.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

