### PR TITLE
Event registration

### DIFF
--- a/src/app/actions/events/actions.ts
+++ b/src/app/actions/events/actions.ts
@@ -15,6 +15,7 @@ interface LeanEvent {
   registrationDeadline?: Date;
   images?: string[];
   registeredUsers?: Types.ObjectId[];
+  registeredChildren?: Types.ObjectId[];
   fee?: number;
 }
 
@@ -36,6 +37,7 @@ export async function getEvents() {
       images: event.images || [],
       currentRegistrations: event.registeredUsers?.length || 0,
       registeredUsers: event.registeredUsers ? event.registeredUsers.map((id) => id.toString()) : [],
+      registeredChildren: event.registeredChildren ? event.registeredChildren.map((id) => id.toString()) : [],
       fee: event.fee,
     }));
 

--- a/src/app/admin/events/edit/[eventID]/page.tsx
+++ b/src/app/admin/events/edit/[eventID]/page.tsx
@@ -112,7 +112,6 @@ const EditEventPage = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
-
       if (!res.ok) {
         const errorData = await res.json();
         throw new Error(errorData.error || "Failed to update event");

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -46,7 +46,7 @@ export default function AdminPage() {
   const handleDeleteEvent = (eventId: string) => {
     setEventSections((prev) => ({
       active: prev.active.filter((event) => event.id !== eventId),
-      upcoming: prev.active.filter((event) => event.id !== eventId),
+      upcoming: prev.upcoming.filter((event) => event.id !== eventId),
       past: prev.past.filter((event) => event.id !== eventId),
     }));
   };

--- a/src/app/api/events/[eventID]/registrations/route.ts
+++ b/src/app/api/events/[eventID]/registrations/route.ts
@@ -82,8 +82,18 @@ export async function PUT(req: NextRequest, { params }: { params: { eventID: str
       return NextResponse.json({ error: "Selected attendees are already registered." }, { status: 400 });
     }
 
-    await event.save();
-    await user.save();
+    const session = await mongoose.startSession();
+    session.startTransaction();
+    try {
+      await event.save({ session });
+      await user.save({ session });
+      await session.commitTransaction();
+    } catch (error) {
+      await session.abortTransaction();
+      // Handle error
+    } finally {
+      session.endSession();
+    }
 
     return NextResponse.json(
       {
@@ -180,8 +190,18 @@ export async function DELETE(req: NextRequest, { params }: { params: { eventID: 
       return NextResponse.json({ error: "Selected attendees were not registered." }, { status: 400 });
     }
 
-    await event.save();
-    await user.save();
+    const session = await mongoose.startSession();
+    session.startTransaction();
+    try {
+      await event.save({ session });
+      await user.save({ session });
+      await session.commitTransaction();
+    } catch (error) {
+      await session.abortTransaction();
+      // Handle error
+    } finally {
+      session.endSession();
+    }
 
     return NextResponse.json(
       {

--- a/src/app/api/events/[eventID]/registrations/route.ts
+++ b/src/app/api/events/[eventID]/registrations/route.ts
@@ -4,6 +4,7 @@ import connectDB from "@/database/db";
 import Event from "@/database/eventSchema";
 import User, { IUser } from "@/database/userSchema";
 import mongoose from "mongoose";
+import { error } from "console";
 
 export async function PUT(req: NextRequest, { params }: { params: { eventID: string } }) {
   await connectDB();
@@ -37,7 +38,7 @@ export async function PUT(req: NextRequest, { params }: { params: { eventID: str
     }
 
     // Ensure only family can be registered
-    const validAttendees = [mongoUserId.toString(), ...user.children.map((child: any) => child._id.toString())];
+    const validAttendees = [mongoUserId, ...user.children.map((child: any) => child._id.toString())];
 
     const isValidRegistration = attendees.every((id) => validAttendees.includes(id));
     if (!isValidRegistration) {
@@ -63,7 +64,7 @@ export async function PUT(req: NextRequest, { params }: { params: { eventID: str
 
     attendees.forEach((id) => {
       // check if the atendee is the user or a child
-      if (id === mongoUserId.toString() && !event.registeredUsers.includes(user._id)) {
+      if (id === mongoUserId && !event.registeredUsers.includes(user._id)) {
         event.registeredUsers.push(user._id);
         user.registeredEvents.push(eventID);
         newRegisteredUsers.push(user._id);
@@ -94,5 +95,101 @@ export async function PUT(req: NextRequest, { params }: { params: { eventID: str
     );
   } catch (error) {
     return NextResponse.json({ error: "Error processing registration" }, { status: 500 });
+  }
+}
+
+// to unregister a user or a child
+export async function DELETE(req: NextRequest, { params }: { params: { eventID: string } }) {
+  await connectDB();
+  const { eventID } = params;
+
+  if (!mongoose.Types.ObjectId.isValid(eventID)) {
+    return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+  }
+
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized. Please log in." }, { status: 401 });
+    }
+
+    const user = await User.findOne({ clerkID: userId });
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const mongoUserId = user._id.toString();
+    const { attendees } = await req.json();
+
+    if (
+      !attendees ||
+      !Array.isArray(attendees) ||
+      attendees.length === 0 ||
+      !attendees.every((id) => mongoose.Types.ObjectId.isValid(id))
+    ) {
+      return NextResponse.json({ error: "Invalid attendees format." }, { status: 400 });
+    }
+
+    // Ensure only family members can be unregistered
+    const validAttendees = [mongoUserId, ...user.children.map((child: any) => child._id.toString())];
+
+    const isValidUnregistration = attendees.every((id) => validAttendees.includes(id));
+    if (!isValidUnregistration) {
+      return NextResponse.json({ error: "You can only unregister yourself or your children." }, { status: 403 });
+    }
+
+    const event = await Event.findById(eventID);
+    if (!event) {
+      return NextResponse.json({ error: "Event not found" }, { status: 404 });
+    }
+
+    if (new Date() > event.endDate) {
+      return NextResponse.json({ error: "You cannot unregister from a past event" }, { status: 400 });
+    }
+
+    // Remove attendees from event
+    let removedUsers: mongoose.Types.ObjectId[] = [];
+    let removedChildren: mongoose.Types.ObjectId[] = [];
+
+    attendees.forEach((id) => {
+      if (id === mongoUserId) {
+        if (event.registeredUsers.includes(user._id)) {
+          event.registeredUsers = event.registeredUsers.filter(
+            (uid: mongoose.Types.ObjectId) => uid.toString() !== mongoUserId,
+          );
+          user.registeredEvents = user.registeredEvents.filter(
+            (eid: mongoose.Types.ObjectId) => eid.toString() !== eventID,
+          );
+          removedUsers.push(user._id);
+        }
+      } else {
+        const child = user.children.find((c: any) => c._id.toString() === id);
+        if (child && event.registeredChildren.includes(child._id)) {
+          event.registeredChildren = event.registeredChildren.filter(
+            (cid: mongoose.Types.ObjectId) => cid.toString() !== child._id.toString(),
+          );
+          child.registeredEvents = child.registeredEvents.filter(
+            (eid: mongoose.Types.ObjectId) => eid.toString() !== eventID,
+          );
+          removedChildren.push(child._id);
+        }
+      }
+    });
+
+    if (removedUsers.length === 0 && removedChildren.length === 0) {
+      return NextResponse.json({ error: "Selected attendees were not registered." }, { status: 400 });
+    }
+
+    await event.save();
+    await user.save();
+
+    return NextResponse.json(
+      {
+        message: "Successfully unregistered",
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json({ error: "Error while unregistering." }, { status: 500 });
   }
 }

--- a/src/app/api/events/[eventID]/registrations/route.ts
+++ b/src/app/api/events/[eventID]/registrations/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import connectDB from "@/database/db";
+import Event from "@/database/eventSchema";
+import User, { IUser } from "@/database/userSchema";
+import mongoose from "mongoose";
+
+export async function PUT(req: NextRequest, { params }: { params: { eventID: string } }) {
+  await connectDB();
+  const { eventID } = params;
+
+  if (!mongoose.Types.ObjectId.isValid(eventID)) {
+    return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+  }
+
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized. Please log in." }, { status: 401 });
+    }
+
+    const user = await User.findOne({ clerkID: userId });
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const mongoUserId = user._id.toString();
+    const { attendees } = await req.json();
+
+    if (
+      !attendees ||
+      !Array.isArray(attendees) ||
+      attendees.length === 0 ||
+      !attendees.every((id) => mongoose.Types.ObjectId.isValid(id))
+    ) {
+      return NextResponse.json({ error: "Invalid attendees format." }, { status: 400 });
+    }
+
+    // Ensure only family can be registered
+    const validAttendees = [mongoUserId.toString(), ...user.children.map((child: any) => child._id.toString())];
+
+    const isValidRegistration = attendees.every((id) => validAttendees.includes(id));
+    if (!isValidRegistration) {
+      return NextResponse.json({ error: "You can only register yourself or your children." }, { status: 403 });
+    }
+
+    const event = await Event.findById(eventID);
+    if (!event) {
+      return NextResponse.json({ error: "Event not found" }, { status: 404 });
+    }
+
+    const requiredCapacity = event.registeredUsers.length + event.registeredChildren.length + attendees.length;
+    if (requiredCapacity > event.capacity) {
+      return NextResponse.json({ error: "The event is too full." }, { status: 400 });
+    }
+
+    if (new Date() > event.registrationDeadline) {
+      return NextResponse.json({ error: "Registration deadline has passed" }, { status: 400 });
+    }
+
+    const newRegisteredUsers: mongoose.Types.ObjectId[] = [];
+    const newRegisteredChildren: mongoose.Types.ObjectId[] = [];
+
+    attendees.forEach((id) => {
+      // check if the atendee is the user or a child
+      if (id === mongoUserId.toString() && !event.registeredUsers.includes(user._id)) {
+        event.registeredUsers.push(user._id);
+        user.registeredEvents.push(eventID);
+        newRegisteredUsers.push(user._id);
+      } else {
+        const child = user.children.find((c: any) => c._id.toString() === id);
+        if (child && !event.registeredChildren.includes(child._id)) {
+          event.registeredChildren.push(child._id);
+          child.registeredEvents.push(eventID);
+          newRegisteredChildren.push(child._id);
+        }
+      }
+    });
+
+    if (newRegisteredChildren.length === 0 && newRegisteredUsers.length === 0) {
+      return NextResponse.json({ error: "Selected attendees are already registered." }, { status: 400 });
+    }
+
+    await event.save();
+    await user.save();
+
+    return NextResponse.json(
+      {
+        message: "Successfully registered",
+        registeredUsers: newRegisteredUsers,
+        registeredChildren: newRegisteredChildren,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json({ error: "Error processing registration" }, { status: 500 });
+  }
+}

--- a/src/app/api/events/[eventID]/route.ts
+++ b/src/app/api/events/[eventID]/route.ts
@@ -21,46 +21,7 @@ export async function PUT(req: NextRequest, { params }: { params: { eventID: str
       return NextResponse.json({ error: "Unauthorized. Please log in." }, { status: 401 });
     }
 
-    // Find user in MongoDB using Clerk ID
-    const person = await User.findOne({ clerkID: userId });
-
-    if (!person) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
-
-    // get their user id to use for registration
-    const mongoUserId = person._id;
-
     const updatedData = await req.json();
-
-    // Check if user is trying to register for event
-    if (updatedData.registerForEvent) {
-      console.log("PUT - registering for events");
-      const event = await Event.findById(eventID);
-      if (!event) {
-        return NextResponse.json({ error: "Event not found" }, { status: 404 });
-      }
-
-      // Check if user already registered for the event
-      if (event.registeredUsers.includes(mongoUserId)) {
-        return NextResponse.json({ error: "User already registered for this event" }, { status: 400 });
-      }
-
-      // Check if the registration deadline passed
-      if (new Date() > event.registrationDeadline) {
-        return NextResponse.json({ error: "Registration deadline has passed" }, { status: 400 });
-      }
-
-      // Check if event is full
-      if (event.capacity > 0 && event.registeredUsers.length >= event.capacity) {
-        return NextResponse.json({ error: "Event is at full capacity." }, { status: 400 });
-      }
-
-      event.registeredUsers.push(mongoUserId);
-      await event.save();
-
-      return NextResponse.json({ message: "Successfully registered for the event.", event }, { status: 200 });
-    }
 
     // If not registering, check if the user is an admin (to update event details)
     const authError = await authenticateAdmin();

--- a/src/app/api/events/[eventID]/route.ts
+++ b/src/app/api/events/[eventID]/route.ts
@@ -6,6 +6,30 @@ import User from "@/database/userSchema";
 import { authenticateAdmin } from "@/lib/auth";
 import { auth } from "@clerk/nextjs/server";
 
+// GET: Fetch a single event by ID
+export async function GET(req: NextRequest, { params }: { params: { eventID: string } }) {
+  await connectDB();
+  const { eventID } = params;
+
+  // Validate the event ID
+  if (!mongoose.Types.ObjectId.isValid(eventID)) {
+    return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+  }
+
+  try {
+    const event = await Event.findById(eventID);
+    if (!event) {
+      return NextResponse.json({ error: "Event not found" }, { status: 404 });
+    }
+    return NextResponse.json(event, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Error fetching event", details: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}
+
 // PUT: Update an Event
 export async function PUT(req: NextRequest, { params }: { params: { eventID: string } }) {
   await connectDB();
@@ -16,7 +40,7 @@ export async function PUT(req: NextRequest, { params }: { params: { eventID: str
   }
 
   try {
-    const { userId } = await auth(); // ✅ Get the authenticated user ID
+    const { userId } = await auth(); // Get the authenticated user ID
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized. Please log in." }, { status: 401 });
     }

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -23,6 +23,7 @@ export async function POST(request: Request) {
     const newEvent = await Event.create({
       ...body,
       registeredUsers: [],
+      registeredChildren: [],
     });
 
     return NextResponse.json(newEvent, { status: 201 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,15 @@ import EventSection from "@/components/EventComponent/EventSection";
 import SkeletonEventSection from "@/components/EventComponent/EventSectionSkeleton";
 import { formatEvents } from "@/lib/utils";
 
+interface IChild {
+  _id: string;
+}
+
+interface IUserData {
+  _id: string;
+  children: IChild[];
+}
+
 export default function Home() {
   // TODO consider more possibilities (children registered, deadline missed, etc) and how to sort those cases
   const [eventSections, setEventSections] = useState<{
@@ -16,7 +25,7 @@ export default function Home() {
     registered: EventInfo[];
     past: EventInfo[];
   }>({ available: [], registered: [], past: [] });
-  const [userData, setUserData] = useState<any>(null);
+  const [userData, setUserData] = useState<IUserData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { isLoaded, user } = useUser();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,9 +69,9 @@ export default function Home() {
 
   return (
     <main className="mx-auto mb-8 flex flex-col">
-      <EventSection title="Registered Events" events={eventSections.registered} isRegisteredSection />
+      <EventSection title="Registered Events" events={eventSections.registered} />
       <EventSection title="Available Events" events={eventSections.available} />
-      <EventSection title="Past Events" events={eventSections.past} isRegisteredSection />
+      <EventSection title="Past Events" events={eventSections.past} />
     </main>
   );
 }

--- a/src/components/EventComponent/EventCard.tsx
+++ b/src/components/EventComponent/EventCard.tsx
@@ -16,7 +16,6 @@ export interface EventCardProps {
   registrationDeadline: Date | null;
   capacity: number;
   currentRegistrations: number;
-  userRegistered?: boolean;
   onDelete?: (eventId: string) => void;
 }
 
@@ -57,7 +56,6 @@ export default function EventCard(props: EventCardProps) {
     registrationDeadline,
     capacity,
     currentRegistrations,
-    userRegistered,
     onDelete,
   } = props;
 
@@ -100,7 +98,6 @@ export default function EventCard(props: EventCardProps) {
             registrationDeadline,
             capacity,
             currentRegistrations,
-            userRegistered,
             onDelete,
           }}
         />

--- a/src/components/EventComponent/EventCard.tsx
+++ b/src/components/EventComponent/EventCard.tsx
@@ -17,6 +17,7 @@ export interface EventCardProps {
   capacity: number;
   currentRegistrations: number;
   onDelete?: (eventId: string) => void;
+  onRegister?: (eventId: string, attendees: string[]) => void;
 }
 
 const InfoRow = ({ icon: Icon, children }: { icon: React.ComponentType<LucideProps>; children: React.ReactNode }) => (
@@ -57,6 +58,7 @@ export default function EventCard(props: EventCardProps) {
     capacity,
     currentRegistrations,
     onDelete,
+    onRegister,
   } = props;
 
   const backgroundImage =
@@ -99,6 +101,7 @@ export default function EventCard(props: EventCardProps) {
             capacity,
             currentRegistrations,
             onDelete,
+            onRegister,
           }}
         />
       </CardContent>

--- a/src/components/EventComponent/EventInfoPreview.tsx
+++ b/src/components/EventComponent/EventInfoPreview.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { SignInButton } from "@clerk/nextjs";
 import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
@@ -289,13 +290,20 @@ export function EventInfoPreview({
             </div>
           </div>
           <DialogFooter className="flex justify-between">
-            <Button
-              className="bg-[#488644] text-white hover:bg-[#3a6d37]"
-              onClick={handleOpenRegisterDialog}
-              disabled={isRegisterDisabled}
-            >
-              {isFull ? "Event Full" : hasRegistrationClosed ? "Registration Closed" : "Register"}
-            </Button>
+            {user ? (
+              <Button
+                className="bg-[#488644] text-white hover:bg-[#3a6d37]"
+                onClick={handleOpenRegisterDialog}
+                disabled={isRegisterDisabled}
+              >
+                {isFull ? "Event Full" : hasRegistrationClosed ? "Registration Closed" : "Register"}
+              </Button>
+            ) : (
+              <SignInButton redirectUrl="/">
+                <Button className="bg-[#488644] text-white hover:bg-[#3a6d37]">Sign In to Register</Button>
+              </SignInButton>
+            )}
+
             {isAdmin && onDelete && (
               <div className="flex justify-end gap-4">
                 <Button variant="outline" onClick={() => handleEditEvent()}>

--- a/src/components/EventComponent/EventInfoPreview.tsx
+++ b/src/components/EventComponent/EventInfoPreview.tsx
@@ -299,7 +299,7 @@ export function EventInfoPreview({
                 {isFull ? "Event Full" : hasRegistrationClosed ? "Registration Closed" : "Register"}
               </Button>
             ) : (
-              <SignInButton redirectUrl="/">
+              <SignInButton>
                 <Button className="bg-[#488644] text-white hover:bg-[#3a6d37]">Sign In to Register</Button>
               </SignInButton>
             )}

--- a/src/components/EventComponent/EventInfoPreview.tsx
+++ b/src/components/EventComponent/EventInfoPreview.tsx
@@ -20,7 +20,6 @@ import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { EventRegisterPreview } from "./EventRegisterPreview";
 import DOMPurify from "dompurify";
-import mongoose from "mongoose";
 
 interface EventInfoProps {
   id: string;
@@ -35,6 +34,7 @@ interface EventInfoProps {
   capacity?: number;
   currentRegistrations?: number;
   onDelete?: (eventId: string) => void;
+  onRegister?: (eventId: string, attendees: string[]) => void;
 }
 
 export function EventInfoPreview({
@@ -50,12 +50,12 @@ export function EventInfoPreview({
   capacity,
   currentRegistrations,
   onDelete,
+  onRegister,
 }: EventInfoProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isRegisterDialogOpen, setIsRegisterDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRegistering, setIsRegistering] = useState(false);
-  const [userFamily, setUserFamily] = useState<{ id: string; name: string }[]>([]);
   const [userInfo, setUserInfo] = useState<{
     id: string;
     name: string;
@@ -73,7 +73,6 @@ export function EventInfoPreview({
   const isAdmin = user?.publicMetadata?.userRole === "admin";
   const sanitizedDescription = DOMPurify.sanitize(description);
 
-  // for registration validation
   const hasRegistrationClosed = registrationDeadline ? new Date() > registrationDeadline : false;
   const isFull = capacity !== undefined && currentRegistrations !== undefined && currentRegistrations >= capacity;
   const [isRegistered, setIsRegistered] = useState(false);
@@ -86,7 +85,6 @@ export function EventInfoPreview({
           "https://creeklands.org/wp-content/uploads/2023/10/creek-lands-conservation-conservation-science-education-central-coast-yes-v1.jpg",
         ];
 
-  // Fetch user's family information when dialog opens
   const fetchUserFamily = async () => {
     if (!user?.id) return;
 
@@ -102,14 +100,13 @@ export function EventInfoPreview({
           alreadyRegistered: child.registeredEvents.includes(id),
         })) || [];
 
-      setUserFamily(family);
       setUserInfo({
         id: userData._id,
         name: `${userData?.firstName || ""} ${userData?.lastName || ""}`.trim(),
         alreadyRegistered: userData.registeredEvents.includes(id),
         family,
       });
-      console.log(family);
+      console.log("Fetched user family:", family);
     } catch (error) {
       console.error("Error fetching user family:", error);
       toast({
@@ -120,7 +117,6 @@ export function EventInfoPreview({
     }
   };
 
-  // Fetch family data when register dialog opens
   const handleOpenRegisterDialog = () => {
     fetchUserFamily();
     setIsRegisterDialogOpen(true);
@@ -129,25 +125,18 @@ export function EventInfoPreview({
   const handleDeleteEvent = async () => {
     setIsDeleting(true);
     try {
-      console.log(id);
-      console.log(title);
       const response = await fetch(`/api/events/${id}`, {
         method: "DELETE",
       });
 
-      if (!response.ok) {
-        throw new Error("Failed to delete event");
-      }
+      if (!response.ok) throw new Error("Failed to delete event");
 
       toast({
         title: "Event deleted successfully",
         description: "The event has been removed from the system.",
       });
 
-      // Calls onDelete to remove deleted events from events instead of full reload
-      if (onDelete) {
-        onDelete(id);
-      }
+      if (onDelete) onDelete(id);
     } catch (error) {
       toast({
         title: "Error",
@@ -161,7 +150,6 @@ export function EventInfoPreview({
   };
 
   const handleRegisterEvent = async (attendees: string[]) => {
-    // make sure you are logged in to register
     if (!user) {
       toast({
         title: "Error",
@@ -174,28 +162,33 @@ export function EventInfoPreview({
     setIsRegistering(true);
 
     try {
-      console.log(id);
-      console.log(title);
+      console.log("Registering attendees:", attendees, "User ID:", userInfo.id);
       const response = await fetch(`/api/events/${id}/registrations`, {
         method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ attendees }),
       });
 
-      // Parse the response body as JSON and handle errors accordingly
       const responseData = await response.json();
+      if (!response.ok) throw new Error(responseData.error || "Failed to register for event.");
 
-      if (!response.ok) {
-        throw new Error(responseData.error || "Failed to register for event.");
-      }
+      // Update local state
+      setIsRegistered(true);
+      setUserInfo((prev) => {
+        const userIsAttendee = attendees.includes(prev.id);
+        console.log("User is attendee:", userIsAttendee);
+        return {
+          ...prev,
+          alreadyRegistered: userIsAttendee ? true : prev.alreadyRegistered,
+          family: prev.family.map((member) => ({
+            ...member,
+            alreadyRegistered: attendees.includes(member.id) ? true : member.alreadyRegistered,
+          })),
+        };
+      });
 
-      // Wait for 3 seconds before reloading the page
-      setTimeout(() => {
-        window.location.reload(); // This will reload the page after the specified delay
-      }, 3000);
-
+      console.log("Parent Signup");
+      onRegister?.(id, attendees);
       toast({
         title: "Registration successful",
         description: "You have been registered for the event.",
@@ -203,7 +196,7 @@ export function EventInfoPreview({
     } catch (error) {
       toast({
         title: "Error",
-        description: error instanceof Error ? error.message : "Failed to register for the event. Please try again.",
+        description: error instanceof Error ? error.message : "Failed to register for the event.",
         variant: "destructive",
       });
     } finally {
@@ -213,7 +206,7 @@ export function EventInfoPreview({
   };
 
   const handleEditEvent = () => {
-    router.push(`/admin/events/edit/${id}`); // Redirect user to the edit page
+    router.push(`/admin/events/edit/${id}`);
   };
 
   return (
@@ -228,13 +221,7 @@ export function EventInfoPreview({
           <DialogHeader>
             <DialogTitle className="text-center text-4xl">{title}</DialogTitle>
           </DialogHeader>
-          <div
-            className="max-h-[60vh] overflow-y-auto px-4 md:px-6 
-            [&::-webkit-scrollbar-thumb]:rounded-full 
-            [&::-webkit-scrollbar-thumb]:bg-slate-300 
-            [&::-webkit-scrollbar-track]:bg-slate-100 
-            [&::-webkit-scrollbar]:w-2"
-          >
+          <div className="max-h-[60vh] overflow-y-auto px-4 md:px-6">
             <div className="grid grid-cols-1 gap-6 py-4 sm:grid-cols-2">
               <div className="grid grid-cols-[auto_1fr] items-center gap-4">
                 <Calendar className="h-5 w-5" />
@@ -303,7 +290,7 @@ export function EventInfoPreview({
           </div>
           <DialogFooter className="flex justify-between">
             <Button
-              className={"bg-[#488644] text-white hover:bg-[#3a6d37]"}
+              className="bg-[#488644] text-white hover:bg-[#3a6d37]"
               onClick={handleOpenRegisterDialog}
               disabled={isRegisterDisabled}
             >

--- a/src/components/EventComponent/EventInfoPreview.tsx
+++ b/src/components/EventComponent/EventInfoPreview.tsx
@@ -58,7 +58,17 @@ export function EventInfoPreview({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRegistering, setIsRegistering] = useState(false);
   const [userFamily, setUserFamily] = useState<{ id: string; name: string }[]>([]);
-  const [userID, setUserID] = useState<string>("");
+  const [userInfo, setUserInfo] = useState<{
+    id: string;
+    name: string;
+    alreadyRegistered: boolean;
+    family: { id: string; name: string; alreadyRegistered: boolean }[];
+  }>({
+    id: "",
+    name: "",
+    alreadyRegistered: false,
+    family: [],
+  });
   const { toast } = useToast();
   const { user } = useUser();
   const router = useRouter();
@@ -87,14 +97,21 @@ export function EventInfoPreview({
       if (!response.ok) throw new Error("Failed to fetch user data");
 
       const userData = await response.json();
-      const familyMembers =
+      const family =
         userData.children?.map((child: any) => ({
           id: child._id,
           name: `${child.firstName || ""} ${child.lastName || ""}`.trim(),
+          alreadyRegistered: child.registeredEvents.includes(id),
         })) || [];
 
-      setUserFamily(familyMembers);
-      setUserID(userData._id);
+      setUserFamily(family);
+      setUserInfo({
+        id: userData._id,
+        name: `${userData?.firstName || ""} ${userData?.lastName || ""}`.trim(),
+        alreadyRegistered: userData.registeredEvents.includes(id),
+        family,
+      });
+      console.log(family);
     } catch (error) {
       console.error("Error fetching user family:", error);
       toast({
@@ -351,11 +368,7 @@ export function EventInfoPreview({
             location: location,
             contactEmail: email || "info@creeklands.org",
           }}
-          userInfo={{
-            id: userID,
-            name: `${user?.firstName || ""} ${user?.lastName || ""}`.trim(),
-            family: userFamily,
-          }}
+          userInfo={userInfo}
           onConfirm={handleRegisterEvent}
         />
       )}

--- a/src/components/EventComponent/EventInfoPreview.tsx
+++ b/src/components/EventComponent/EventInfoPreview.tsx
@@ -34,7 +34,6 @@ interface EventInfoProps {
   email?: string;
   capacity?: number;
   currentRegistrations?: number;
-  userRegistered?: boolean;
   onDelete?: (eventId: string) => void;
 }
 
@@ -50,7 +49,6 @@ export function EventInfoPreview({
   email = "info@creeklands.org",
   capacity,
   currentRegistrations,
-  userRegistered,
   onDelete,
 }: EventInfoProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -79,7 +77,7 @@ export function EventInfoPreview({
   const hasRegistrationClosed = registrationDeadline ? new Date() > registrationDeadline : false;
   const isFull = capacity !== undefined && currentRegistrations !== undefined && currentRegistrations >= capacity;
   const [isRegistered, setIsRegistered] = useState(false);
-  const isRegisterDisabled = hasRegistrationClosed || isFull || isRegistered;
+  const isRegisterDisabled = hasRegistrationClosed || isFull;
 
   const eventImages =
     images.length > 0
@@ -305,17 +303,11 @@ export function EventInfoPreview({
           </div>
           <DialogFooter className="flex justify-between">
             <Button
-              className={`text-white ${userRegistered ? "cursor-not-allowed bg-gray-400" : "bg-[#488644] text-white hover:bg-[#3a6d37]"}`}
+              className={"bg-[#488644] text-white hover:bg-[#3a6d37]"}
               onClick={handleOpenRegisterDialog}
               disabled={isRegisterDisabled}
             >
-              {isFull
-                ? "Event Full"
-                : hasRegistrationClosed
-                  ? "Registration Closed"
-                  : userRegistered
-                    ? "Already Registered"
-                    : "Register"}
+              {isFull ? "Event Full" : hasRegistrationClosed ? "Registration Closed" : "Register"}
             </Button>
             {isAdmin && onDelete && (
               <div className="flex justify-end gap-4">
@@ -353,7 +345,7 @@ export function EventInfoPreview({
         </AlertDialogContent>
       </AlertDialog>
 
-      {!isFull && !userRegistered && (
+      {!isFull && (
         <EventRegisterPreview
           isOpen={isRegisterDialogOpen}
           onOpenChange={setIsRegisterDialogOpen}

--- a/src/components/EventComponent/EventInfoPreview.tsx
+++ b/src/components/EventComponent/EventInfoPreview.tsx
@@ -18,6 +18,7 @@ import {
 import { SignInButton } from "@clerk/nextjs";
 import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@clerk/nextjs";
+import { usePathname } from "next/navigation";
 import { useRouter } from "next/navigation";
 import { EventRegisterPreview } from "./EventRegisterPreview";
 import DOMPurify from "dompurify";
@@ -72,6 +73,8 @@ export function EventInfoPreview({
   const { user } = useUser();
   const router = useRouter();
   const isAdmin = user?.publicMetadata?.userRole === "admin";
+  const pathname = usePathname();
+  const showRegisterButton = !pathname.startsWith("/admin/events");
   const sanitizedDescription = DOMPurify.sanitize(description);
 
   const hasRegistrationClosed = registrationDeadline ? new Date() > registrationDeadline : false;
@@ -290,19 +293,20 @@ export function EventInfoPreview({
             </div>
           </div>
           <DialogFooter className="flex justify-between">
-            {user ? (
-              <Button
-                className="bg-[#488644] text-white hover:bg-[#3a6d37]"
-                onClick={handleOpenRegisterDialog}
-                disabled={isRegisterDisabled}
-              >
-                {isFull ? "Event Full" : hasRegistrationClosed ? "Registration Closed" : "Register"}
-              </Button>
-            ) : (
-              <SignInButton>
-                <Button className="bg-[#488644] text-white hover:bg-[#3a6d37]">Sign In to Register</Button>
-              </SignInButton>
-            )}
+            {showRegisterButton &&
+              (user ? (
+                <Button
+                  className="bg-[#488644] text-white hover:bg-[#3a6d37]"
+                  onClick={handleOpenRegisterDialog}
+                  disabled={isRegisterDisabled}
+                >
+                  {isFull ? "Event Full" : hasRegistrationClosed ? "Registration Closed" : "Register"}
+                </Button>
+              ) : (
+                <SignInButton>
+                  <Button className="bg-[#488644] text-white hover:bg-[#3a6d37]">Sign In to Register</Button>
+                </SignInButton>
+              ))}
 
             {isAdmin && onDelete && (
               <div className="flex justify-end gap-4">

--- a/src/components/EventComponent/EventRegisterPreview.tsx
+++ b/src/components/EventComponent/EventRegisterPreview.tsx
@@ -22,7 +22,8 @@ interface RegisterDialogProps {
   userInfo: {
     id: string;
     name: string;
-    family: { id: string; name: string }[];
+    alreadyRegistered: boolean;
+    family: { id: string; name: string; alreadyRegistered: boolean }[];
   };
   onConfirm: (attendees: string[]) => void;
 }
@@ -71,18 +72,20 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
               <div className="flex items-center space-x-3">
                 <Checkbox
                   id={userInfo.id}
-                  checked={selectedAttendees.includes(userInfo.id)}
+                  checked={selectedAttendees.includes(userInfo.id) || userInfo.alreadyRegistered}
                   onCheckedChange={(checked) => {
                     setSelectedAttendees((prev) =>
                       checked ? [...prev, userInfo.id] : prev.filter((id) => id !== userInfo.id),
                     );
                   }}
+                  disabled={userInfo.alreadyRegistered}
                 />
                 <label
                   htmlFor={userInfo.id}
                   className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                 >
                   {userInfo.name}
+                  {userInfo.alreadyRegistered && <span>(already registered)</span>}
                 </label>
               </div>
               {userInfo.family.map((member) => (
@@ -90,12 +93,13 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
                   <Checkbox
                     key={member.id}
                     id={member.id}
-                    checked={selectedAttendees.includes(member.id)}
+                    checked={selectedAttendees.includes(member.id) || member.alreadyRegistered}
                     onCheckedChange={(checked) => {
                       setSelectedAttendees((prev) =>
                         checked ? [...prev, member.id] : prev.filter((name) => name !== member.id),
                       );
                     }}
+                    disabled={member.alreadyRegistered}
                   />
                   <label
                     htmlFor={member.id}

--- a/src/components/EventComponent/EventRegisterPreview.tsx
+++ b/src/components/EventComponent/EventRegisterPreview.tsx
@@ -3,9 +3,10 @@
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Calendar, Clock, MapPin, Mail, Check, Download } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
 
 interface RegisterDialogProps {
   isOpen: boolean;
@@ -32,14 +33,30 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
   const [selectedAttendees, setSelectedAttendees] = useState<string[]>([]);
   const [waiverEmail, setWaiverEmail] = useState("");
   const [waiverSigned, setWaiverSigned] = useState(false);
+  const { toast } = useToast();
 
   const allRegistered = userInfo.alreadyRegistered && userInfo.family.every((member) => member.alreadyRegistered);
 
   const handleClick = () => {
     if (selectedAttendees.length > 0) {
       onConfirm(selectedAttendees);
+    } else {
+      // Assuming a toast component exists
+      toast({
+        title: "No Attendees Selected",
+        description: "Please select at least one attendee to register.",
+        variant: "destructive",
+      });
     }
   };
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedAttendees([]);
+      setWaiverEmail("");
+      setWaiverSigned(false);
+    }
+  }, [isOpen]);
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -89,7 +106,7 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
                   className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                 >
                   {userInfo.name}
-                  {userInfo.alreadyRegistered && <span>(already registered)</span>}
+                  {userInfo.alreadyRegistered}
                 </label>
               </div>
               {userInfo.family.map((member) => (
@@ -100,7 +117,7 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
                     checked={selectedAttendees.includes(member.id) || member.alreadyRegistered}
                     onCheckedChange={(checked) => {
                       setSelectedAttendees((prev) =>
-                        checked ? [...prev, member.id] : prev.filter((name) => name !== member.id),
+                        checked ? [...prev, member.id] : prev.filter((id) => id !== member.id),
                       );
                     }}
                     disabled={member.alreadyRegistered}

--- a/src/components/EventComponent/EventRegisterPreview.tsx
+++ b/src/components/EventComponent/EventRegisterPreview.tsx
@@ -33,8 +33,12 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
   const [waiverEmail, setWaiverEmail] = useState("");
   const [waiverSigned, setWaiverSigned] = useState(false);
 
+  const allRegistered = userInfo.alreadyRegistered && userInfo.family.every((member) => member.alreadyRegistered);
+
   const handleClick = () => {
-    onConfirm(selectedAttendees);
+    if (selectedAttendees.length > 0) {
+      onConfirm(selectedAttendees);
+    }
   };
 
   return (
@@ -152,13 +156,21 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
 
         <DialogFooter className="mt-6">
           {!waiverSigned && (
-            <Button className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]" onClick={handleClick}>
-              Register for Event
+            <Button
+              className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]"
+              onClick={handleClick}
+              disabled={allRegistered}
+            >
+              {allRegistered ? "All Family Members Registered" : "Register for Event"}
             </Button>
           )}
           {waiverSigned && (
-            <Button className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]" onClick={handleClick}>
-              Sign and Return to Events
+            <Button
+              className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]"
+              onClick={handleClick}
+              disabled={allRegistered}
+            >
+              {allRegistered ? "All Family Members Registered" : "Sign and Return to Events"}
             </Button>
           )}
         </DialogFooter>

--- a/src/components/EventComponent/EventRegisterPreview.tsx
+++ b/src/components/EventComponent/EventRegisterPreview.tsx
@@ -41,7 +41,6 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
     if (selectedAttendees.length > 0) {
       onConfirm(selectedAttendees);
     } else {
-      // Assuming a toast component exists
       toast({
         title: "No Attendees Selected",
         description: "Please select at least one attendee to register.",
@@ -60,13 +59,13 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[75vw] min-w-[900px] p-8">
+      <DialogContent className="h-auto max-h-[70vh] w-full max-w-[80%] overflow-y-auto rounded-lg md:max-w-[700px] lg:max-w-[900px]">
         <DialogHeader className="items-center">
           <div className="mb-2 flex items-center justify-between">
-            <DialogTitle className="text-3xl font-bold">Register for: {eventInfo.title}</DialogTitle>
+            <DialogTitle className="text-2xl font-bold sm:text-3xl">Register for: {eventInfo.title}</DialogTitle>
           </div>
 
-          <div className="flex gap-6 text-sm text-gray-600">
+          <div className="flex flex-col gap-2 text-xs text-gray-600 sm:flex-row sm:gap-6 sm:text-sm">
             <div className="flex items-center gap-2">
               <Calendar className="h-4 w-4" />
               {eventInfo.startDate} - {eventInfo.endDate}
@@ -86,7 +85,7 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
           </div>
         </DialogHeader>
 
-        <div className="mt-2 grid grid-cols-2 gap-12">
+        <div className="mt-2 grid grid-cols-1 gap-6 md:grid-cols-2">
           <div className="w-full">
             <h3 className="mb-4 font-semibold">Who&apos;s attending?</h3>
             <div className="space-y-3">
@@ -106,13 +105,12 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
                   className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                 >
                   {userInfo.name}
-                  {userInfo.alreadyRegistered}
+                  {userInfo.alreadyRegistered && " (Already Registered)"}
                 </label>
               </div>
               {userInfo.family.map((member) => (
-                <div key={member.name} className="flex items-center space-x-3">
+                <div key={member.id} className="flex items-center space-x-3">
                   <Checkbox
-                    key={member.id}
                     id={member.id}
                     checked={selectedAttendees.includes(member.id) || member.alreadyRegistered}
                     onCheckedChange={(checked) => {
@@ -127,6 +125,7 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                   >
                     {member.name}
+                    {member.alreadyRegistered && " (Already Registered)"}
                   </label>
                 </div>
               ))}
@@ -154,7 +153,7 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
                   placeholder="e.g. jameshudson345@gmail.com"
                   value={waiverEmail}
                   onChange={(e) => setWaiverEmail(e.target.value)}
-                  className="mt-1"
+                  className="mt-1 w-full"
                 />
               </div>
 
@@ -174,7 +173,7 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
         <DialogFooter className="mt-6">
           {!waiverSigned && (
             <Button
-              className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]"
+              className="mx-auto w-full bg-[#488644] text-white hover:bg-[#3a6d37] sm:w-2/5"
               onClick={handleClick}
               disabled={allRegistered}
             >
@@ -183,7 +182,7 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
           )}
           {waiverSigned && (
             <Button
-              className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]"
+              className="mx-auto w-full bg-[#488644] text-white hover:bg-[#3a6d37] sm:w-2/5"
               onClick={handleClick}
               disabled={allRegistered}
             >

--- a/src/components/EventComponent/EventRegisterPreview.tsx
+++ b/src/components/EventComponent/EventRegisterPreview.tsx
@@ -20,16 +20,21 @@ interface RegisterDialogProps {
     contactEmail: string;
   };
   userInfo: {
+    id: string;
     name: string;
-    family: { name: string }[];
+    family: { id: string; name: string }[];
   };
-  onConfirm: () => void;
+  onConfirm: (attendees: string[]) => void;
 }
 
 export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo, onConfirm }: RegisterDialogProps) {
   const [selectedAttendees, setSelectedAttendees] = useState<string[]>([]);
   const [waiverEmail, setWaiverEmail] = useState("");
   const [waiverSigned, setWaiverSigned] = useState(false);
+
+  const handleClick = () => {
+    onConfirm(selectedAttendees);
+  };
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -65,16 +70,16 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
             <div className="space-y-3">
               <div className="flex items-center space-x-3">
                 <Checkbox
-                  id={userInfo.name}
-                  checked={selectedAttendees.includes(userInfo.name)}
+                  id={userInfo.id}
+                  checked={selectedAttendees.includes(userInfo.id)}
                   onCheckedChange={(checked) => {
                     setSelectedAttendees((prev) =>
-                      checked ? [...prev, userInfo.name] : prev.filter((name) => name !== userInfo.name),
+                      checked ? [...prev, userInfo.id] : prev.filter((id) => id !== userInfo.id),
                     );
                   }}
                 />
                 <label
-                  htmlFor={userInfo.name}
+                  htmlFor={userInfo.id}
                   className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                 >
                   {userInfo.name}
@@ -83,16 +88,17 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
               {userInfo.family.map((member) => (
                 <div key={member.name} className="flex items-center space-x-3">
                   <Checkbox
-                    id={member.name}
-                    checked={selectedAttendees.includes(member.name)}
+                    key={member.id}
+                    id={member.id}
+                    checked={selectedAttendees.includes(member.id)}
                     onCheckedChange={(checked) => {
                       setSelectedAttendees((prev) =>
-                        checked ? [...prev, member.name] : prev.filter((name) => name !== member.name),
+                        checked ? [...prev, member.id] : prev.filter((name) => name !== member.id),
                       );
                     }}
                   />
                   <label
-                    htmlFor={member.name}
+                    htmlFor={member.id}
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                   >
                     {member.name}
@@ -142,12 +148,12 @@ export function EventRegisterPreview({ isOpen, onOpenChange, eventInfo, userInfo
 
         <DialogFooter className="mt-6">
           {!waiverSigned && (
-            <Button className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]" onClick={onConfirm}>
+            <Button className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]" onClick={handleClick}>
               Register for Event
             </Button>
           )}
           {waiverSigned && (
-            <Button className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]" onClick={onConfirm}>
+            <Button className="mx-auto w-2/5 bg-[#488644] text-white hover:bg-[#3a6d37]" onClick={handleClick}>
               Sign and Return to Events
             </Button>
           )}

--- a/src/components/EventComponent/EventSection.tsx
+++ b/src/components/EventComponent/EventSection.tsx
@@ -64,7 +64,8 @@ export default function EventSection({
                 key={event.id}
                 {...event}
                 eventTitle={event.title}
-                currentRegistrations={event.registeredUsers.length}
+                // most events do not yet reflect the addition of registeredChildren to the schema
+                currentRegistrations={event.registeredUsers.length + event.registeredChildren.length}
                 userRegistered={isRegisteredSection}
                 onDelete={onDelete}
               />

--- a/src/components/EventComponent/EventSection.tsx
+++ b/src/components/EventComponent/EventSection.tsx
@@ -7,13 +7,11 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
 export default function EventSection({
   title,
   events,
-  isRegisteredSection = false,
   onDelete,
   children,
 }: {
   title: string;
   events: EventInfo[];
-  isRegisteredSection?: boolean;
   onDelete?: (eventId: string) => void;
   children?: React.ReactNode;
 }) {
@@ -66,7 +64,6 @@ export default function EventSection({
                 eventTitle={event.title}
                 // most events do not yet reflect the addition of registeredChildren to the schema
                 currentRegistrations={event.registeredUsers.length + event.registeredChildren.length}
-                userRegistered={isRegisteredSection}
                 onDelete={onDelete}
               />
             ))}

--- a/src/components/EventComponent/EventSection.tsx
+++ b/src/components/EventComponent/EventSection.tsx
@@ -8,11 +8,13 @@ export default function EventSection({
   title,
   events,
   onDelete,
+  onRegister,
   children,
 }: {
   title: string;
   events: EventInfo[];
   onDelete?: (eventId: string) => void;
+  onRegister?: (eventId: string, attendees: string[]) => void;
   children?: React.ReactNode;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -65,6 +67,7 @@ export default function EventSection({
                 // most events do not yet reflect the addition of registeredChildren to the schema
                 currentRegistrations={event.registeredUsers.length + event.registeredChildren.length}
                 onDelete={onDelete}
+                onRegister={onRegister}
               />
             ))}
           </div>

--- a/src/database/eventSchema.ts
+++ b/src/database/eventSchema.ts
@@ -11,6 +11,7 @@ export interface IEvent extends Document {
   registrationDeadline: Date;
   images: string[];
   registeredUsers: mongoose.Types.ObjectId[];
+  registeredChildren: mongoose.Types.ObjectId[];
   waiverId: mongoose.Types.ObjectId[];
   fee: number;
   stripePaymentId?: string | null;
@@ -78,7 +79,7 @@ const eventSchema = new Schema<IEvent>(
     },
     images: [{ type: String, default: [] }],
     registeredUsers: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }], // Change ObjectId to String
-
+    registeredChildren: [{ type: mongoose.Schema.Types.ObjectId, ref: "User.children" }],
     waiverId: [{ type: mongoose.Schema.Types.ObjectId, ref: "Waiver" }],
     fee: {
       type: Number,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,4 +31,5 @@ export const formatEvents = (data: any[]): EventInfo[] =>
     registrationDeadline: event.registrationDeadline ? new Date(event.registrationDeadline) : null,
     capacity: event.capacity || 0,
     registeredUsers: event.registeredUsers?.map((u: any) => u.toString()) || [],
+    registeredChildren: event.registeredChildren?.map((c: any) => c.toString()) || [],
   }));

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -23,4 +23,5 @@ export type EventInfo = {
   registrationDeadline: Date | null;
   capacity: number;
   registeredUsers: string[];
+  registeredChildren: string[];
 };


### PR DESCRIPTION
## Developer: Kevin Diaz

Closes #78 

### Pull Request Summary

- `/api/events/[eventID]/registrations` new endpoint for handling registering (PUT) and unregistering (DELETE) from an event. I have not edited the front end to support unregistering but the endpoint is there now. I figured admins and users should not be using the same endpoint, and that registrations have enough functions to warrant their own endpoint rather than let the admin endpoints become huge.
- Front end now properly calculates spots filled, allows child registration, displays appropriate error messages, and sorts the event into the registered section if a user's child is registered.

### Modifications

- `src/app/actions/events/actions.ts` events are now returned with the registeredChildren attribute, defaults to an empty list if undefined.
- `src/app/api/events/route.ts` registeredChildren initialized to empty list upon event creation
- `src/app/page.tsx` changes to event section sorting
- `src/components/EventComponent/EventInfoPreview.tsx` fetchUserFamily and HandleRegisterEvent now fetch and update the correct data to allow for children registration. The Register preview no longer becomes disabled if a single user/child is registered.
- `src/components/EventComponent/EventRegisterPreview.tsx` checkboxes now deal with mongo _ids instead of names, and become disabled if that user/child is already registered. button becomes disabled if the whole family is registered
  - I think eventually both these components will need to be modified to allow for more registration options (unregistering, maybe even a waitlist or something) so whenever that happens the logic for the buttons can be revised further.
- `src/lib/utils.ts` formatEvents helper function now handles registeredChildren (defaults to empty if undefined)
- `src/types/events.ts` now reflects the registeredChildren prop
- `eventSchema.ts` added the new registeredChildren field

### Testing Considerations

I've checked that:
- capacity is properly updated
- the checkboxes become disabled if already registered
- no "registeredChildren is undefined" errors appear
- the event, user, and children are properly updated in mongo
- a user can't send a request on postman to register a random kid
- they can't register other users either.
- any errors that come up are displayed on a toast

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
![image](https://github.com/user-attachments/assets/96e6b954-7850-4f84-8606-98065dcaf301)



